### PR TITLE
add condition for ExRAM writes during render

### DIFF
--- a/mappers/005/map_005.v
+++ b/mappers/005/map_005.v
@@ -270,7 +270,7 @@ module map_005 //MMC5
 	
 	wire xram_ce_cpu = {cpu_addr[15:10], 10'd0} == 16'h5C00;
 	wire xram_oe_cpu = xram_ce_cpu & cpu_rw & exram_mode[1] == 1;
-	wire xram_we_cpu = ss_act ? xram_we_sst : xram_ce_cpu & exram_mode[1:0] != 2'b11;
+	wire xram_we_cpu = ss_act ? xram_we_sst : xram_ce_cpu & !cpu_rw & exram_mode[1:0] != 2'b11;
 	
 
 	xram xram_inst(


### PR DESCRIPTION
This fixes games which write to ExRAM during render in ExRAM mode 1.

There was an incorrect condition for writing to ExRAM during render which caused graphical glitches due to wrong palette and bank choices.

Here are a few examples:

[Just Breed example 1 (before)](https://i.imgur.com/8JMTUqX.jpg)

[Just Breed example 1 (after)](https://i.imgur.com/WrjHg1h.jpg)

[Just Breed example 2 (before)](https://i.imgur.com/2J7X4iL.jpg)

[Just Breed example 2 (after)](https://i.imgur.com/JqKemoO.jpg)

[Yakuman Tengoku (before)](https://i.imgur.com/xyCraqS.jpg)

[Yakuman Tengoku (after)](https://i.imgur.com/cgmZjqw.jpg)

In Just Breed, the corruption would happen whenever there was a dialogue box since they write to ExRAM live to render the box.  In Yakuman Tengoku, it would consistently corrupt ExRAM whenever you get to the second row of Mahjong tiles.  This can be seen in Yakuman Tegoku (before) on the bottom left; there is some red overlapping the left player's bottom tile that doesn't belong there.  You can check this for yourself by playing the game and repeatedly pressing A until your second row is placed down (You may have to try a couple times in case someone wins before the second row starts).

If you need any more tests or evidence, please let me know and I'd be happy to work on that and provide them.