### PR TITLE
n163 freq fix

### DIFF
--- a/mappers/019/snd-n163.sv
+++ b/mappers/019/snd-n163.sv
@@ -106,7 +106,7 @@ module snd_n163(
 			end
 			7:begin
 				inst_vol[3:0] <= dout_snd[3:0];
-				if(64-inst_len == phase[23:18])phase[23:16] <= 0;
+				if(64-inst_len == phase[23:18])phase[23:18] <= 0;
 				if(ram_addr_snd == 7'h7f)chans_on[2:0] <= dout_snd[6:4];
 			end
 			8:begin

--- a/mappers/031/snd-n163.sv
+++ b/mappers/031/snd-n163.sv
@@ -106,7 +106,7 @@ module snd_n163(
 			end
 			7:begin
 				inst_vol[3:0] <= dout_snd[3:0];
-				if(64-inst_len == phase[23:18])phase[23:16] <= 0;
+				if(64-inst_len == phase[23:18])phase[23:18] <= 0;
 				if(ram_addr_snd == 7'h7f)chans_on[2:0] <= dout_snd[6:4];
 			end
 			8:begin


### PR DESCRIPTION
this commit fixes a phase-related issue with the n163 sound module, causing inaccurate note frequencies

https://github.com/krikzz/EDN8-PRO/assets/88253410/764af5db-7c8a-4303-9d7d-7c1be45ff738

