### PR TITLE
Add support for oversize MMC3

### DIFF
--- a/mappers/004/map_004.sv
+++ b/mappers/004/map_004.sv
@@ -55,7 +55,7 @@ module map_004(//MMC3
 	assign prg.oe 				= cpu.rw;
 	assign prg.we				= 0;
 	assign prg.addr[12:0]	= cpu.addr[12:0];
-	assign prg.addr[18:13]	= prg_addr[18:13];
+	assign prg.addr[20:13]	= prg_addr[20:13];
 	
 	assign chr.ce 				= mao.ciram_ce;
 	assign chr.oe 				= !ppu.oe;
@@ -76,7 +76,7 @@ module map_004(//MMC3
 	wire ram_ce_n;
 	wire ram_we_n;
 	wire prg_ce_n;
-	wire [18:13]prg_addr;
+	wire [20:13]prg_addr;
 	wire [17:10]chr_addr;
 	
 	wire [7:0]sst_di;

--- a/mappers/004/map_004_s1.sv
+++ b/mappers/004/map_004_s1.sv
@@ -57,7 +57,7 @@ module map_004_s1(//MMC6
 	assign prg.oe 				= cpu.rw;
 	assign prg.we				= 0;
 	assign prg.addr[12:0]	= cpu.addr[12:0];
-	assign prg.addr[18:13]	= prg_addr[18:13];
+	assign prg.addr[20:13]	= prg_addr[20:13];
 	
 	assign chr.ce 				= mao.ciram_ce;
 	assign chr.oe 				= !ppu.oe;
@@ -77,7 +77,7 @@ module map_004_s1(//MMC6
 	wire irq_n;
 	wire ciram_a10;
 	wire prg_ce_n;
-	wire [18:13]prg_addr;
+	wire [20:13]prg_addr;
 	wire [17:10]chr_addr;
 	
 	wire [7:0]sst_di;

--- a/mappers/004/map_004_s3.sv
+++ b/mappers/004/map_004_s3.sv
@@ -56,7 +56,7 @@ module map_004_s3(//Acclaim mmc3 modification. Everything the same except irq
 	assign prg.oe 				= cpu.rw;
 	assign prg.we				= 0;
 	assign prg.addr[12:0]	= cpu.addr[12:0];
-	assign prg.addr[18:13]	= prg_addr[18:13];
+	assign prg.addr[20:13]	= prg_addr[20:13];
 	
 	assign chr.ce 				= mao.ciram_ce;
 	assign chr.oe 				= !ppu.oe;
@@ -77,7 +77,7 @@ module map_004_s3(//Acclaim mmc3 modification. Everything the same except irq
 	wire ram_ce_n;
 	wire ram_we_n;	
 	wire prg_ce_n;
-	wire [18:13]prg_addr;
+	wire [20:13]prg_addr;
 	wire [17:10]chr_addr;
 	
 	wire [7:0]sst_di_mmc;


### PR DESCRIPTION
Use all 8 bits of the PRG ROM bank registers instead of just the bottom 6, allowing for 1 megabyte and 2 megabyte PRG ROM.